### PR TITLE
On-load focus on the text box

### DIFF
--- a/templates/yamli.html
+++ b/templates/yamli.html
@@ -59,6 +59,9 @@ $(document).ready(function() {
 
     $("#arabictextbox").one("keypress", set_ltr);
 
+    //set initial focus to the textbox so the user can simply start typing when the website has loaded
+    $("#arabictextbox").focus();
+
     // check if Yamli has updated
     $(".yamliapi_inst_ff_arabictextbox.yamliapi_menuContent").live("DOMSubtreeModified",function(){
         // find what's in the textbox


### PR DESCRIPTION
I've ended up using this dictionary quite a bit. A small thing that's bothered me a little is that you have to click on the text box before you can start typing. The following patch sets the focus on the text box when the page is loaded, so that the user can start typing right away.
